### PR TITLE
Update scikit-learn version to 1.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ pybear = [
     {version = "==0.2.5", python = "==3.14"}   # can only be ">=0.2.4"
 ]
 scikit-learn = [
-    {version = ">=1.3.0,==1.4.2,<1.7,<1.8", python = "==3.10"},    # 1.4.2 not working; 1.5.0-1.6.1 work; 1.7.0 not working
-	{version = ">=1.3.0,==1.4.2,<1.7", python = "==3.11"},    # 1.4.2 not working; 1.5.0-1.6.1 work; 1.7.0 not working
-	{version = ">=1.3.1,==1.5.0,<1.7", python = "==3.12"},    # 1.4.2 not working; 1.5.0-1.6.1 work; 1.7.0 not working
+    {version = ">=1.3.0,==1.5.2,<1.7,<1.8", python = "==3.10"},    # 1.4.2 not working; 1.5.0-1.6.1 work; 1.7.0 not working
+	{version = ">=1.3.0,==1.5.2,<1.7", python = "==3.11"},    # 1.4.2 not working; 1.5.0-1.6.1 work; 1.7.0 not working
+	{version = ">=1.3.1,==1.5.2,<1.7", python = "==3.12"},    # 1.4.2 not working; 1.5.0-1.6.1 work; 1.7.0 not working
 	{version = ">=1.6.1,==1.6.1,<2.0", python = "==3.13"},    # must be >= 1.6.1; 1.6.1-1.9.0 work
 	{version = ">=1.7.2,==1.7.2,<2.0", python = "==3.14"}     # must be >= 1.7.2; 1.7.2-1.9.0 work
 ]


### PR DESCRIPTION
Updated scikit-learn version constraints for compatibility with Python versions 3.10, 3.11, and 3.12.