### PR TITLE
dep floor testing 118

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dask = [
     {version = ">=2025.1.0", python = "==3.14"},   # must be >= 2025.1.0; 2025.4.0-2025.4.1 not working
 ]
 dask-expr = [
-    {version = ">=1.0,==1.21.0,<2.0.0", python = "==3.10"},
+    {version = ">=1.0,==1.1.21,<2.0.0", python = "==3.10"},
 #    {version = "*", python = "==3.11"},
 #    {version = "*", python = "==3.12"},
 ]


### PR DESCRIPTION
Updated dask-expr version constraint for Python 3.10.